### PR TITLE
Fix: Extracted UserId is Always the Internal Keycloak Id When REST API is Used

### DIFF
--- a/examples/sso-kubernetes/src/main/java/org/camunda/bpm/extension/keycloak/showcase/rest/KeycloakAuthenticationFilter.java
+++ b/examples/sso-kubernetes/src/main/java/org/camunda/bpm/extension/keycloak/showcase/rest/KeycloakAuthenticationFilter.java
@@ -34,14 +34,17 @@ public class KeycloakAuthenticationFilter implements Filter {
 	
 	/** Access to the OAuth2 client service. */
 	OAuth2AuthorizedClientService clientService;
+
+	private String userNameAttribute;
 	
 	/**
 	 * Creates a new KeycloakAuthenticationFilter.
 	 * @param identityService access to Camunda's IdentityService
 	 */
-	public KeycloakAuthenticationFilter(IdentityService identityService, OAuth2AuthorizedClientService clientService) {
+	public KeycloakAuthenticationFilter(IdentityService identityService, OAuth2AuthorizedClientService clientService, String userNameAttribute) {
 		this.identityService = identityService;
 		this.clientService = clientService;
+		this.userNameAttribute = userNameAttribute;
 	}
 
 	/**
@@ -55,7 +58,9 @@ public class KeycloakAuthenticationFilter implements Filter {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		String userId = null;
 		if (authentication instanceof JwtAuthenticationToken) {
-			userId = ((JwtAuthenticationToken)authentication).getName();
+			//userId = ((JwtAuthenticationToken)authentication).getName();
+			userId = ((JwtAuthenticationToken) authentication).getTokenAttributes().get(userNameAttribute).toString();
+			
 		} else if (authentication.getPrincipal() instanceof OidcUser) {
 			userId = ((OidcUser)authentication.getPrincipal()).getName();
 		} else {

--- a/examples/sso-kubernetes/src/main/java/org/camunda/bpm/extension/keycloak/showcase/rest/RestApiSecurityConfig.java
+++ b/examples/sso-kubernetes/src/main/java/org/camunda/bpm/extension/keycloak/showcase/rest/RestApiSecurityConfig.java
@@ -95,7 +95,12 @@ public class RestApiSecurityConfig extends WebSecurityConfigurerAdapter {
 	@Bean
     public FilterRegistrationBean keycloakAuthenticationFilter(){
         FilterRegistrationBean filterRegistration = new FilterRegistrationBean();
-        filterRegistration.setFilter(new KeycloakAuthenticationFilter(identityService, clientService));
+		
+		String userNameAttribute = this.applicationContext.getEnvironment().getRequiredProperty(
+			"spring.security.oauth2.client.provider." + this.configProps.getProvider() + ".user-name-attribute");
+    
+    	filterRegistration.setFilter(new KeycloakAuthenticationFilter(this.identityService, this.clientService, userNameAttribute));
+        
         filterRegistration.setOrder(102); // make sure the filter is registered after the Spring Security Filter Chain
         filterRegistration.addUrlPatterns("/engine-rest/*");
         return filterRegistration;


### PR DESCRIPTION
# Camunda Keycloak Identity Provider Pull Request

Fix: Extracted UserId is Always the Internal Keycloak Id When REST API is Used

https://github.com/camunda-community-hub/camunda-platform-7-keycloak/issues/104
