### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Dependabot Config
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# Camunda Keycloak Identity Provider Pull Request

<!--- Provide a general summary of your changes in the issue title above. Do not @ GitHub users in your pull request title. If your extension is still a work in progress, please add [WIP] to the title so that your pull request will not be flagged as mergable. When your PR is ready to be merged, you can remove [WIP] from the title. -->

## Description
Enable GitHub Dependabot to keep track of 3rd party dependency updates, security alerts and make life a little easier.
The bot will automatically create PR based upon the defined dependencies as well as github-actions if there are updates available.

## Additional context
<!--- Why is this change needed? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some people prefer [renovate ](https://github.com/renovatebot/renovate) nowadays, however _ol' reliable_ dependabot does the trick for me and I think it would make maintenance of this extension a little easier.

## Testing your changes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include any relevant details as to your testing environment, and any tests you ran to determine how/if your change impacts other areas of the extension's codebase, etc. -->
I can't test these changes on a fork, however I assume it is still required to enable security alerts in the repo settings:
https://github.com/camunda-community-hub/camunda-platform-7-keycloak/settings/security_analysis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
<!--- Please review the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation
- [x] I have read the **Pull Request Process** documentation
- [ ] I have added or suggested tests to cover my changes suggested in this pull request.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @celanthe in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's Maintainer
