### PR TITLE
When retrieving user by ID request just exact match

### DIFF
--- a/extension/src/main/java/org/camunda/bpm/extension/keycloak/KeycloakServiceBase.java
+++ b/extension/src/main/java/org/camunda/bpm/extension/keycloak/KeycloakServiceBase.java
@@ -60,9 +60,9 @@ public abstract class KeycloakServiceBase {
 	protected String getKeycloakUserID(String userId) throws KeycloakUserNotFoundException, RestClientException {
 		String userSearch;
 		if (keycloakConfiguration.isUseEmailAsCamundaUserId()) {
-			userSearch= "/users?email=";
+			userSearch= "/users?exact=true&email=";
 		} else if (keycloakConfiguration.isUseUsernameAsCamundaUserId()) {
-			userSearch="/users?username=";
+			userSearch="/users?exact=true&username=";
 		} else {
 			return userId;
 		}

--- a/extension/src/main/java/org/camunda/bpm/extension/keycloak/KeycloakUserService.java
+++ b/extension/src/main/java/org/camunda/bpm/extension/keycloak/KeycloakUserService.java
@@ -309,9 +309,9 @@ public class KeycloakUserService extends KeycloakServiceBase {
 		try {
 			String userSearch;
 			if (keycloakConfiguration.isUseEmailAsCamundaUserId()) {
-				userSearch="/users?email=" + userId;
+				userSearch="/users?exact=true&email=" + userId;
 			} else if (keycloakConfiguration.isUseUsernameAsCamundaUserId()) {
-				userSearch="/users?username=" + userId;
+				userSearch="/users?exact=true&username=" + userId;
 			} else {
 				userSearch= "/users/" + userId;
 			}


### PR DESCRIPTION
# Camunda Keycloak Identity Provider Pull Request

When retrieving user by ID request just exact match, otherwise user might not be able to login when many similar usernames exists.

## Description
Otherwise when there are over 100 results that does not match exactly, login to web UI with NPE.
For example you are trying to login as user with username `tester`. But in the Keycloak, there are users such as `tester1`, `tester2`, `stester1` and so on. Once the number of those users is large enough, you would not be able to login. This is because when retrieving list of users from Keycloak it is doing "fulltext search" on usernames and the user you are logging in with might not be in the results. Keycloak returns first 100 results but those are not sorted by the best match. configuration value `maxResultSize` is not used for such calls.
Since we need to retrieve just one exact user we should use a parameter of Keycloak REST API that requests only the user that returns exactly matching username.

## Testing your changes
Having a deployment with many users with just a number suffix, we were not able to login to the Camunda web UI.
Once deployed local build of proposed change, user were able to log in and list groups that user is a member of.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an existing open issue)
- [ ] New feature (non-breaking change which adds functionality to an extension)
- [ ] Breaking change (fix or feature that would cause existing functionality of an extension to change)
- [ ] Documentation update (changes made to an existing piece of documentation)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [ ] My pull request requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation
- [x] I have read the **Pull Request Process** documentation
- [ ] I have added or suggested tests to cover my changes suggested in this pull request.
- [ ] All new and existing CI/CD tests passed.
- [ ] I will /assign myself this issue, and add the relevant [issue labels] to it if they are not automatically generated by Probot.
- [x] I will tag @celanthe in a new comment on this issue if 30 days have passed since my pull request was opened and I have not received a response from the extension's Maintainer
