### PR TITLE
Update link to Keycloak Docker Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Known limitations:
 
 ## Prerequisites in your Keycloak realm
 
-1. Keycloak docker images can be found on [Keycloak Docker Hub](https://hub.docker.com/r/jboss/keycloak/ "Keycloak Docker Images").
+1. Keycloak docker images can be found on [Keycloak Docker Hub](https://hub.docker.com/r/keycloak/keycloak "Keycloak Docker Images").
 2. Create a new client named `camunda-identity-service` with access type confidential and service accounts enabled:
     ![IdentityServiceSettings](doc/identity-service_settings.png "Identity Service Settings")
    Please be aware, that beginning with Keycloak 18, you do not only have to configure a valid redirect URL, but


### PR DESCRIPTION
# Camunda Keycloak Identity Provider Pull Request

## Description
Fixes the incorrect link to Keycloak's Docker Hub in the README.md.

## Additional context
The previous link was outdated or misdirecting, causing confusion. This update ensures users are redirected to the correct Docker Hub page.

## Testing your changes
Manually verified the link in the README.md and confirmed it redirects correctly to Keycloak's Docker Hub.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an existing open issue)
- [x] Documentation update (changes made to an existing piece of documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code adheres to the syntax used by this extension.
- [x] My pull request requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **Camunda Community Hub** documentation.
- [x] I have read the **Pull Request Process** documentation.
- [x] I have added or suggested tests to cover my changes.
- [x] All new and existing CI/CD tests passed.
- [x] I will /assign myself this issue, and add the relevant [issue labels] if they are not automatically generated by Probot.
- [x] I will tag @celanthe in a new comment on this issue if 30 days pass without a response from the maintainer.
